### PR TITLE
fix regression with DTypes in type-safe tensors

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -7,6 +7,7 @@ import           Naperian
 import           Torch.Naperian
 import           Data.Naperian.Examples
 import qualified Torch.Tensor                  as D
+import qualified Torch.DType                   as D
 import qualified Torch.Autograd                as A
 import           Torch.Static                  as S
 import           Torch.Static.Factories        as S
@@ -14,29 +15,29 @@ import           Torch.Static.Factories        as S
 main :: IO ()
 main = do
     putStrLn "--- Dim fold ---"
-    let dim :: Dim '[2] '[Vector 3] Float
+    let dim :: Dim '[2] '[Vector 3] 'D.Float
         dim = Dim (pure ones)
-        summed :: Dim '[2] '[] Float
+        summed :: Dim '[2] '[] 'D.Float
         summed = foldrDimLayer add ones dim
     print dim
     print summed
     putStrLn "--- Tensor unbind ---"
-    let test1 = ones :: S.Tensor Float '[3,2]
+    let test1 = ones :: S.Tensor 'D.Float '[3,2]
         test1Dyn = toDynamic test1
     print test1Dyn
     print (unbindDynamic test1Dyn)
     print (unbind test1)
     putStrLn "--- Dim unbind ---"
-    print (dimUp dim :: Dim '[] '[Vector 2, Vector 3] Float)
+    print (dimUp dim :: Dim '[] '[Vector 2, Vector 3] 'D.Float)
     putStrLn "--- Tensor stack ---"
-    let test2 = ones :: S.Tensor Float '[2]
+    let test2 = ones :: S.Tensor 'D.Float '[2]
         test2Dyn = toDynamic test2
     print test2Dyn
     print (stackDynamic [test2Dyn, test2Dyn, test2Dyn])
-    print (stack [test2, test2, test2] :: S.Tensor Float '[3, 2])
+    print (stack [test2, test2, test2] :: S.Tensor 'D.Float '[3, 2])
     putStrLn "--- Dim stack ---"
-    print (dimDown dim :: Dim '[3, 2] '[] Float)
+    print (dimDown dim :: Dim '[3, 2] '[] 'D.Float)
     putStrLn "--- Dim cat ---"
     print (dimCat dim)
     putStrLn "--- Dim chunk ---"
-    print (dimChunk dim :: Dim '[1] '[Vector 2, Vector 3] Float)
+    print (dimChunk dim :: Dim '[1] '[Vector 2, Vector 3] 'D.Float)


### PR DESCRIPTION
hi @jasigal, current `Torch.Static.Tensor`s require a type variable of kind `DType` in first position. this fixes the build of hasktorch-naperian :)